### PR TITLE
PS_FST_TYPE_CRYPTO is not in libprocstat.h anymore

### DIFF
--- a/bsd/_bsd.pyx
+++ b/bsd/_bsd.pyx
@@ -78,7 +78,6 @@ class DescriptorType(enum.IntEnum):
     PIPE = defs.PS_FST_TYPE_PIPE
     PTS = defs.PS_FST_TYPE_PTS
     KQUEUE = defs.PS_FST_TYPE_KQUEUE
-    CRYPTO = defs.PS_FST_TYPE_CRYPTO
     MQUEUE = defs.PS_FST_TYPE_MQUEUE
     SHM = defs.PS_FST_TYPE_SHM
     SEM = defs.PS_FST_TYPE_SEM

--- a/defs.pxd
+++ b/defs.pxd
@@ -319,7 +319,6 @@ cdef extern from "libprocstat.h" nogil:
         PS_FST_TYPE_PIPE
         PS_FST_TYPE_PTS
         PS_FST_TYPE_KQUEUE
-        PS_FST_TYPE_CRYPTO
         PS_FST_TYPE_MQUEUE
         PS_FST_TYPE_SHM
         PS_FST_TYPE_SEM


### PR DESCRIPTION
See freebsd/freebsd-src@688f8b822cea550753e7f3495339141cb6b565b7