### PR TITLE
NAS-112679 / add functions for querying disk size

### DIFF
--- a/bsd/disk.pyx
+++ b/bsd/disk.pyx
@@ -1,0 +1,27 @@
+from array import array
+from struct import unpack
+from fcntl import ioctl
+
+from . cimport disk_ioctl
+
+
+def get_size_with_name(disk):
+    """
+    Get size of disk in bytes.
+
+    `disk` must be a string and can be `/dev/da1` or just `da1`
+    """
+    disk = disk.removeprefix('/dev/')
+    with open(f'/dev/{disk}', 'rb') as f:
+        return get_size_with_file(f)
+
+
+def get_size_with_file(f):
+    """
+    Get size of disk in bytes.
+
+    `disk` must be a python file object.
+    """
+    _buffer = array('B', range(0, 8))
+    ioctl(f.fileno(), disk_ioctl.DIOCGMEDIASIZE, _buffer, 1)
+    return unpack('q', _buffer)[0]

--- a/bsd/disk_ioctl.pxd
+++ b/bsd/disk_ioctl.pxd
@@ -1,0 +1,3 @@
+cdef extern from "sys/disk.h":
+    enum:
+        DIOCGMEDIASIZE

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ extensions = [
         "bsd.enclosure",
         ["bsd/enclosure.pyx"],
     ),
+    Extension(
+        "bsd.disk",
+        ["bsd/disk.pyx"],
+    ),
 ]
 
 


### PR DESCRIPTION
This is a simple function that will be used in 12/13 branches of TrueNAS CORE for more efficient querying of disk information (instead of using `subprocess` like we're doing now).

Biggest reason is to not have to hard-code the `DIOCGMEDIASIZE` ioctl and instead import it here so this hopefully doesn't break on newer freeBSD releases.