### PR TITLE
NAS-115928 / 13.0 / stop geom.scan() at module import

### DIFF
--- a/bsd/geom.py
+++ b/bsd/geom.py
@@ -280,7 +280,6 @@ def provider_by_id(ident):
     return _providers[ident]
 
 
-# Do initial scan at module load time
 # Yeah, no, don't do this. On a large system, it was discovered
 # this module was using ~24MB of resident memory. (tested on ~1240 disk system)
 # scan()

--- a/bsd/geom.py
+++ b/bsd/geom.py
@@ -281,4 +281,6 @@ def provider_by_id(ident):
 
 
 # Do initial scan at module load time
-scan()
+# Yeah, no, don't do this. On a large system, it was discovered
+# this module was using ~24MB of resident memory. (tested on ~1240 disk system)
+# scan()


### PR DESCRIPTION
`geom.scan()` at module import time didn't really age well....especially on large systems.

I've found that this was reportedly eating ~24MB of resident memory size on a large system (~1240 hard drives) but once I removed this it actually reclaimed around ~54MB of resident memory.....

I've already mostly replaced the necessity of this module by writing a caching service native to `middlewared` so this isn't needed anymore.