### PR TITLE
NAS-116100 / 13.0 / fix incorrect assumption of how cython operates

### DIFF
--- a/bsd/enclosure.pyx
+++ b/bsd/enclosure.pyx
@@ -2,14 +2,12 @@
 
 from . cimport ses
 
-from libc.stdint cimport uint16_t
 from posix.ioctl cimport ioctl
 from posix.fcntl cimport open, O_RDWR
 from posix.unistd cimport close
 from posix.strings cimport bzero
 from libc.stdlib cimport calloc, free
 from libc.stdint cimport UINT16_MAX
-from libc.string cimport strdup
 
 
 cdef class Enclosure(object):
@@ -46,138 +44,100 @@ cdef class Enclosure(object):
         cdef int num_elms = 0
         cdef int elm_name_size = 128
         cdef ses.u_char estat
-        cdef ses.elm_info_t * elm_info = NULL
 
+        enc_info = {'name': '', 'id': '', 'status': [], 'elements': {}}
+
+        # enclosure name
         enc_name.bufsiz = sizeof(_enc_name)
         enc_name.buf = &_enc_name[0]
+        res = ioctl(self.enc_fd, ses.ENCIOC_GETENCNAME, <ses.caddr_t>&enc_name)
+        if res != 0:
+            raise RuntimeError('ioctl failed to get enclosure name')
+        else:
+            enc_info['name'] = enc_name.buf.strip()
+
+        # enclosure id
         enc_id.bufsiz = sizeof(_enc_id)
         enc_id.buf = &_enc_id[0]
-        try:
-            with nogil:
-                # enclosure name
-                res = ioctl(self.enc_fd, ses.ENCIOC_GETENCNAME, <ses.caddr_t>&enc_name)
-                if res != 0:
-                    raise RuntimeError('ioctl failed to get enclosure name')
-
-                # enclosure id
-                res = ioctl(self.enc_fd, ses.ENCIOC_GETENCID, <ses.caddr_t>&enc_id)
-                if res != 0:
-                    raise RuntimeError('ioctl failed to get enclosure id')
-
-                # number of enclosure elements
-                res = ioctl(self.enc_fd, ses.ENCIOC_GETNELM, <ses.caddr_t>&num_elms)
-                if res < 0:
-                    raise RuntimeError('ioctl failed to get number of elements')
-
-                # enclosure status
-                res = ioctl(self.enc_fd, ses.ENCIOC_GETENCSTAT, <ses.caddr_t>&estat)
-                if res != 0:
-                    raise RuntimeError('ioctl failed to get enclosure status')
-
-                objp = <ses.encioc_element_t*>calloc(num_elms, sizeof(ses.encioc_element_t))
-                if not objp:
-                    raise MemoryError('calloc objp failed')
-
-                elm_info = <ses.elm_info_t*>calloc(num_elms, sizeof(ses.elm_info_t))
-                if not elm_info:
-                    raise MemoryError('calloc elm_info failed')
-
-                res = ioctl(self.enc_fd, ses.ENCIOC_GETELMMAP, <ses.caddr_t>objp)
-                if res < 0:
-                    raise RuntimeError('ioctl failed to get enclosure element map')
-
-                # get each elements status and store in an array
-                for i in range(num_elms):
-                    ob.elm_idx = objp[i].elm_idx
-                    res = ioctl(self.enc_fd, ses.ENCIOC_GETELMSTAT, <ses.caddr_t>&ob)
-                    if res < 0:
-                        raise RuntimeError('ioctl failed to get element status')
-
-                    # copy out element id
-                    elm_info[i].idx = ob.elm_idx
-
-                    # copy out element type
-                    elm_info[i].elm_type = objp[i].elm_type
-
-                    # copy out element status (always size 4)
-                    elm_info[i].cstat[0] = ob.cstat[0]
-                    elm_info[i].cstat[1] = ob.cstat[1]
-                    elm_info[i].cstat[2] = ob.cstat[2]
-                    elm_info[i].cstat[3] = ob.cstat[3]
-
-                    bzero(&objd, sizeof(objd))
-                    objd.elm_idx = objp[i].elm_idx
-                    objd.elm_desc_len = UINT16_MAX
-                    objd.elm_desc_str = <char*>calloc(UINT16_MAX, sizeof(char))
-                    elm_info[i].elm_desc_str = objd.elm_desc_str
-                    if not objd.elm_desc_str:
-                        raise MemoryError('calloc objd.elm_desc_str failed')
-                    else:
-                        res = ioctl(self.enc_fd, ses.ENCIOC_GETELMDESC, <ses.caddr_t>&objd)
-                        if res < 0:
-                            raise RuntimeError('ioctl failed to get element description')
-
-                    bzero(&objdn, sizeof(objdn))
-                    objdn.elm_idx = objp[i].elm_idx
-                    objdn.elm_names_size = elm_name_size
-                    objdn.elm_devnames = <char*>calloc(elm_name_size, sizeof(char))
-                    elm_info[i].elm_devnames = objdn.elm_devnames
-                    if not objdn.elm_devnames:
-                        raise MemoryError('calloc elm_devnames failed')
-                    else:
-                        # apparently this isn't critical and can return -1
-                        # so we ignore the returned value
-                        ioctl(self.enc_fd, ses.ENCIOC_GETELMDEVNAMES, <ses.caddr_t>&objdn)
-
-            enc_info = {
-                'name': '',
-                'id': '',
-                'status': set(),
-                'elements': {},
-            }
-
-            # pull out enclosure name and id
-            enc_info['name'] = enc_name.buf.strip()
+        res = ioctl(self.enc_fd, ses.ENCIOC_GETENCID, <ses.caddr_t>&enc_id)
+        if res != 0:
+            raise RuntimeError('ioctl failed to get enclosure id')
+        else:
             enc_info['id'] = enc_id.buf.strip()
 
-            # pull out enclosure status
+        # enclosure status
+        res = ioctl(self.enc_fd, ses.ENCIOC_GETENCSTAT, <ses.caddr_t>&estat)
+        if res != 0:
+            raise RuntimeError('ioctl failed to get enclosure status')
+        else:
             if estat == 0:
-                enc_info['status'].add('OK')
+                enc_info['status'].append('OK')
             else:
                 if (estat & ses.SES_ENCSTAT_INFO):
-                    enc_info['status'].add('INFO')
+                    enc_info['status'].append('INFO')
                 if (estat & ses.SES_ENCSTAT_NONCRITICAL):
-                    enc_info['status'].add('NONCRITICAL')
+                    enc_info['status'].append('NONCRITICAL')
                 if (estat & ses.SES_ENCSTAT_CRITICAL):
-                    enc_info['status'].add('CRITICAL')
+                    enc_info['status'].append('CRITICAL')
                 if (estat & ses.SES_ENCSTAT_UNRECOV):
-                    enc_info['status'].add('UNRECOV')
+                    enc_info['status'].append('UNRECOV')
 
-            # pull out enclosure element info
-            for i in range(num_elms):
-                enc_info['elements'].update({
-                    elm_info[i].idx: {
-                        'type': elm_info[i].elm_type,
-                        'status': [elm_info[i].cstat[j] for j in range(4)],
-                        'descriptor': elm_info[i].elm_desc_str.strip(),
-                        'dev': elm_info[i].elm_devnames.strip(),
-                    }
-                })
-            return enc_info
-        finally:
-            with nogil:
-                self.clean_up(num_elms, elm_info, objp)
+        # query all elements returned by ses device
+        res = ioctl(self.enc_fd, ses.ENCIOC_GETNELM, <ses.caddr_t>&num_elms)
+        if res < 0:
+            raise RuntimeError('ioctl failed to get number of elements')
 
-    cdef void clean_up(self, int num_elms, ses.elm_info_t *elm_info, ses.encioc_element_t *objp) nogil:
-        cdef int i;
-        if objp != NULL:
-            free(objp)
+        objp = <ses.encioc_element_t*>calloc(num_elms, sizeof(ses.encioc_element_t))
+        if not objp:
+            raise MemoryError('calloc objp failed')
 
-        if elm_info != NULL:
-            for i in range(num_elms):
-                free(elm_info[i].elm_desc_str)
-                free(elm_info[i].elm_devnames)
-            free(elm_info)
+        res = ioctl(self.enc_fd, ses.ENCIOC_GETELMMAP, <ses.caddr_t>objp)
+        if res < 0:
+            raise RuntimeError('ioctl failed to get enclosure element map')
+
+        # we've got number of elements and mapped them, now iterate through
+        # them and get their information
+        for i in range(num_elms):
+            ob.elm_idx = objp[i].elm_idx
+            res = ioctl(self.enc_fd, ses.ENCIOC_GETELMSTAT, <ses.caddr_t>&ob)
+            if res < 0:
+                raise RuntimeError('ioctl failed to get element status')
+
+            element = {
+                ob.elm_idx: {
+                    'type': objp[i].elm_type,
+                    'status': [ob.cstat[j] for j in range(4)],
+                    'descriptor': '',
+                    'dev': '',
+                }
+            }
+
+            # element descriptor info
+            bzero(&objd, sizeof(objd))
+            objd.elm_idx = objp[i].elm_idx
+            objd.elm_desc_len = UINT16_MAX
+            objd.elm_desc_str = <char*>calloc(UINT16_MAX, sizeof(char))
+            res = ioctl(self.enc_fd, ses.ENCIOC_GETELMDESC, <ses.caddr_t>&objd)
+            if res < 0:
+                raise RuntimeError('ioctl failed to get element description')
+            else:
+                element[ob.elm_idx]['descriptor'] = objd.elm_desc_str.strip()
+                free(objd.elm_desc_str)
+
+            # devices connected to element
+            bzero(&objdn, sizeof(objdn))
+            objdn.elm_idx = objp[i].elm_idx
+            objdn.elm_names_size = elm_name_size
+            objdn.elm_devnames = <char*>calloc(elm_name_size, sizeof(char))
+            ioctl(self.enc_fd, ses.ENCIOC_GETELMDEVNAMES, <ses.caddr_t>&objdn)
+            element[ob.elm_idx]['dev'] = objdn.elm_devnames.strip()
+            free(objdn.elm_devnames)
+
+            # update the final dict
+            enc_info['elements'].update(element)
+
+        free(objp)
+        return enc_info
 
     cdef int setobj(self, long element, unsigned char *action) except -1:
         cdef ses.encioc_elm_status_t obj

--- a/bsd/ses.pxd
+++ b/bsd/ses.pxd
@@ -4,18 +4,6 @@ from cython import size_t
 from libc.stdint cimport uint8_t, uint16_t
 
 
-# used to store the elements related
-# information all at once so we dont
-# have to drop/reacquire the GIL for
-# each element detected in an enclosure
-cdef struct elm_info_t:
-    unsigned int idx  # element index
-    unsigned char cstat[4]  # element status
-    char * elm_desc_str  # element descriptor
-    char * elm_devnames  # devices attached to element
-    elm_type_t elm_type
-
-
 cdef extern from "sys/types.h":
     ctypedef long caddr_t
     ctypedef unsigned char u_char


### PR DESCRIPTION
Cython and scoping don't follow the same rules as C. When cython allocates on the stack is vastly different than C.

Long story kept short, I tried to be fancy and release the gil once, get all the enclosure element information and then free the heap before returning. Turns out, dropping the GIL probably doesn't really gain much of a performance improvement in the first place anyways but more importantly, it allows me to remove the code that I put in to try and make all that work.

Even though testing this code in an interpreter running `while true; do bsd.Enclosure('/dev/ses10').status(); done` never "leaked", the moment this was used in our long-running `middlewared` process, the memory grew many hundreds of MBs before eventually "plateauing" out.

A strange, frustrating issue.

The fix is simple, remove the for loop, allocate and free as I go along to each element. Testing this in the `middlewared` process has "plugged" the "leak".